### PR TITLE
Naming the image created with docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,6 +7,7 @@ services:
             args:
                 UID: "${UID:-1000}"
                 GID: "${GID:-1000}"
+        image: sameday-php-sdk
         tty: true
         volumes:
             - .:/var/www/php-sdk:rw


### PR DESCRIPTION
For consistency purposes, we define the name of the image built with docker-compose.