### PR TITLE
Add supportedPayment and clientVisible to LockerObject

### DIFF
--- a/src/Sameday/Objects/Locker/LockerObject.php
+++ b/src/Sameday/Objects/Locker/LockerObject.php
@@ -56,6 +56,16 @@ class LockerObject
     protected $email;
 
     /**
+     * @var int 0 = doesn't support payment, 1 = supports payment
+     */
+    protected $supportedPayment;
+
+    /**
+     * @var int 0 = not visible, 1 = visible
+     */
+    protected $clientVisible;
+
+    /**
      * @var BoxObject[]
      */
     protected $boxes;
@@ -78,6 +88,8 @@ class LockerObject
      * @param string $long
      * @param string $phone
      * @param string $email
+     * @param int $supportedPayment
+     * @param int $clientVisible
      * @param BoxObject[] $boxes
      * @param ScheduleObject[] $schedule
      */
@@ -92,6 +104,8 @@ class LockerObject
         $long,
         $phone,
         $email,
+        $supportedPayment,
+        $clientVisible,
         array $boxes,
         array $schedule
     ) {
@@ -105,6 +119,8 @@ class LockerObject
         $this->long = $long;
         $this->phone = $phone;
         $this->email = $email;
+        $this->supportedPayment = $supportedPayment;
+        $this->clientVisible = $clientVisible;
         $this->boxes = $boxes;
         $this->schedule = $schedule;
     }
@@ -171,6 +187,22 @@ class LockerObject
     public function getEmail()
     {
         return $this->email;
+    }
+
+    /**
+     * @return int
+     */
+    public function getSupportedPayment()
+    {
+        return $this->supportedPayment;
+    }
+
+    /**
+     * @return int
+     */
+    public function getClientVisible()
+    {
+        return $this->clientVisible;
     }
 
     /**

--- a/src/Sameday/Responses/SamedayGetLockersResponse.php
+++ b/src/Sameday/Responses/SamedayGetLockersResponse.php
@@ -52,6 +52,8 @@ class SamedayGetLockersResponse implements SamedayResponseInterface
                 $locker['lng'],
                 $locker['phone'],
                 $locker['email'],
+                $locker['supportedPayment'],
+                $locker['clientVisible'],
                 array_map(
                     function ($entry) {
                         return new BoxObject(

--- a/tests/Responses/SamedayGetLockersResponseTest.php
+++ b/tests/Responses/SamedayGetLockersResponseTest.php
@@ -52,6 +52,8 @@ class SamedayGetLockersResponseTest extends TestCase
             }
         ],
         "lockerId": 2,
+        "supportedPayment": 1,
+        "clientVisible": 1,
         "schedule": [
             {
                 "day": 1,
@@ -115,6 +117,8 @@ class SamedayGetLockersResponseTest extends TestCase
             }
         ],
         "lockerId": 1,
+        "supportedPayment": 0,
+        "clientVisible": 0,
         "schedule": [
             {
                 "day": 1,
@@ -173,6 +177,8 @@ JSON
                 '26.098118',
                 '1234567890',
                 'foo@bar.com',
+                1,
+                1,
                 [
                     new BoxObject('S', 15),
                     new BoxObject('M', 9),
@@ -203,6 +209,8 @@ JSON
                 '26.124641',
                 '0987654321',
                 'bar@foo.com',
+                0,
+                0,
                 [
                     new BoxObject('S', 20),
                     new BoxObject('M', 14),


### PR DESCRIPTION
Fixes #27 by mapping `supportedPayment` and `clientVisible` response fields to `Sameday\Objects\Locker\LockerObject`