### PR TITLE
PHP 8.1 compatibility

### DIFF
--- a/src/Sameday/Http/RequestBodyUrlEncoded.php
+++ b/src/Sameday/Http/RequestBodyUrlEncoded.php
@@ -29,6 +29,6 @@ class RequestBodyUrlEncoded implements RequestBodyInterface
      */
     public function getBody()
     {
-        return http_build_query($this->params, null, '&');
+        return http_build_query($this->params, '', '&');
     }
 }

--- a/src/Sameday/SamedayClient.php
+++ b/src/Sameday/SamedayClient.php
@@ -116,7 +116,7 @@ class SamedayClient implements SamedayClientInterface
 
         $url = $this->host . $request->getEndpoint();
         if ($request->getQueryParams()) {
-            $params = http_build_query($request->getQueryParams(), null, '&');
+            $params = http_build_query($request->getQueryParams(), '', '&');
             if ($params !== '') {
                 $url .= '?' . $params;
             }


### PR DESCRIPTION
PHP Deprecated: http_build_query(): Passing null to parameter #2 ($numeric_prefix) of type string is deprecated in vendor/sameday-courier/php-sdk/src/Sameday/Http/RequestBodyUrlEncoded.php on line 32