### PR TITLE
SamedayGetParcelStatusHistoryResponse

### DIFF
--- a/src/Sameday/Responses/SamedayGetParcelStatusHistoryResponse.php
+++ b/src/Sameday/Responses/SamedayGetParcelStatusHistoryResponse.php
@@ -111,7 +111,7 @@ class SamedayGetParcelStatusHistoryResponse implements SamedayResponseInterface
             $json['statusLabel'],
             $json['statusState'],
             new DateTime($json['statusDate']),
-            $json['county'],
+            isset($json['county']) ? $json['county'] : null,
             $json['reason'],
             $json['transitLocation']
         );
@@ -132,7 +132,7 @@ class SamedayGetParcelStatusHistoryResponse implements SamedayResponseInterface
             $json['statusLabel'],
             $json['statusState'],
             new DateTime($json['statusDate']),
-            $json['county'],
+            isset($json['county']) ? $json['county'] : null,
             $json['reason'],
             $json['transitLocation'],
             $json['expeditionDetails']

--- a/src/Sameday/Responses/SamedayGetParcelStatusHistoryResponse.php
+++ b/src/Sameday/Responses/SamedayGetParcelStatusHistoryResponse.php
@@ -111,7 +111,7 @@ class SamedayGetParcelStatusHistoryResponse implements SamedayResponseInterface
             $json['statusLabel'],
             $json['statusState'],
             new DateTime($json['statusDate']),
-            isset($json['county']) ? $json['county'] : null,
+            $json['county'] ?: null,
             $json['reason'],
             $json['transitLocation']
         );
@@ -132,7 +132,7 @@ class SamedayGetParcelStatusHistoryResponse implements SamedayResponseInterface
             $json['statusLabel'],
             $json['statusState'],
             new DateTime($json['statusDate']),
-            isset($json['county']) ? $json['county'] : null,
+            $json['county'] ?: null,
             $json['reason'],
             $json['transitLocation'],
             $json['expeditionDetails']

--- a/src/Sameday/SamedayClient.php
+++ b/src/Sameday/SamedayClient.php
@@ -27,7 +27,7 @@ use Sameday\Responses\SamedayAuthenticateResponse;
  */
 class SamedayClient implements SamedayClientInterface
 {
-    const VERSION = '2.1.5';
+    const VERSION = '2.1.6';
     const API_HOST = 'https://api.sameday.ro';
     const KEY_TOKEN = 'token';
     const KEY_TOKEN_EXPIRES = 'expires_at';


### PR DESCRIPTION
Fix issue. Deal with undefined 'county' index on SamedayGetParcelStatusHistoryResponse response returned by API.
Example of response:
{
   "statusId":1,
   "status":"AWB Emis",
   "statusLabel":"Document de transport emis",
   "statusState":"Ridicam coletul in curand",
   "statusDate":"2024-03-05T15:01:53+02:00",
   "reason":"",
   "transitLocation":"",
  }